### PR TITLE
extract common functionality to function

### DIFF
--- a/lib/moodle_lib/client/cohorts.ex
+++ b/lib/moodle_lib/client/cohorts.ex
@@ -1,10 +1,9 @@
 defmodule MoodleLib.Client.Cohorts do
-  import MoodleLib.Client.Common, only: [process_request: 1]
+  import MoodleLib.Client.Common, only: [process_request: 2]
 
   def get_cohort(id) do
     %{"cohortids[0]" => id}
-    |> Map.put(:wsfunction, :core_cohort_get_cohorts)
-    |> process_request()
+    |> process_request(:core_cohort_get_cohorts)
     |> handle_got_cohort()
   end
 
@@ -14,22 +13,19 @@ defmodule MoodleLib.Client.Cohorts do
     |> Map.put("categorytype][value", "ignored")
     |> Enum.map(fn {k, v} -> {"cohorts[0][#{k}]", v} end)
     |> Map.new()
-    |> Map.put(:wsfunction, :core_cohort_create_cohorts)
-    |> process_request()
+    |> process_request(:core_cohort_create_cohorts)
     |> handle_created_cohort()
   end
 
   def delete_cohort(id) do
     %{"cohortids[0]" => id}
-    |> Map.put(:wsfunction, :core_cohort_delete_cohorts)
-    |> process_request()
+    |> process_request(:core_cohort_delete_cohorts)
     |> handle_cohort_deleted()
   end
 
   def get_cohort_members(id) do
     %{"cohortids[0]" => id}
-    |> Map.put(:wsfunction, :core_cohort_get_cohort_members)
-    |> process_request()
+    |> process_request(:core_cohort_get_cohort_members)
     |> handle_got_cohort_members()
   end
 
@@ -40,8 +36,7 @@ defmodule MoodleLib.Client.Cohorts do
       "members[0][usertype][type]" => "id",
       "members[0][usertype][value]" => user.id
     }
-    |> Map.put(:wsfunction, :core_cohort_add_cohort_members)
-    |> process_request()
+    |> process_request(:core_cohort_add_cohort_members)
     |> handle_added_cohort_member(cohort.id)
   end
 
@@ -50,8 +45,7 @@ defmodule MoodleLib.Client.Cohorts do
       "members[0][cohortid]" => cohort.id,
       "members[0][userid]" => user.id
     }
-    |> Map.put(:wsfunction, :core_cohort_delete_cohort_members)
-    |> process_request()
+    |> process_request(:core_cohort_delete_cohort_members)
     |> handle_removed_cohort_member(cohort.id)
   end
 

--- a/lib/moodle_lib/client/common.ex
+++ b/lib/moodle_lib/client/common.ex
@@ -1,6 +1,7 @@
 defmodule MoodleLib.Client.Common do
-  def process_request(params) do
+  def process_request(params, fn_name) do
     params
+    |> Map.put(:wsfunction, fn_name)
     |> build_uri()
     |> HTTPoison.get!()
     |> extract_body()

--- a/lib/moodle_lib/client/users.ex
+++ b/lib/moodle_lib/client/users.ex
@@ -1,22 +1,20 @@
 defmodule MoodleLib.Client.Users do
   alias MoodleLib.User
 
-  import MoodleLib.Client.Common, only: [process_request: 1]
+  import MoodleLib.Client.Common, only: [process_request: 2]
 
   def create_user(user_params) do
     user_params
     |> build_user()
     |> prepare_user()
     |> to_querystring()
-    |> Map.put(:wsfunction, :core_user_create_users)
-    |> process_request()
+    |> process_request(:core_user_create_users)
     |> handle_user_created()
   end
 
   def delete_user(id) do
     %{"userids[0]" => id}
-    |> Map.put(:wsfunction, :core_user_delete_users)
-    |> process_request()
+    |> process_request(:core_user_delete_users)
     |> handle_user_deleted()
   end
 
@@ -31,8 +29,7 @@ defmodule MoodleLib.Client.Users do
       "criteria[0][key]" => "id",
       "criteria[0][value]" => id
     }
-    |> Map.put(:wsfunction, :core_user_get_users)
-    |> process_request()
+    |> process_request(:core_user_get_users)
     |> handle_got_user()
   end
 
@@ -42,8 +39,7 @@ defmodule MoodleLib.Client.Users do
     |> Enum.map(fn {id, idx} -> {"values[#{idx}]", id} end)
     |> Map.new()
     |> Map.put(:field, :id)
-    |> Map.put(:wsfunction, :core_user_get_users_by_field)
-    |> process_request()
+    |> process_request(:core_user_get_users_by_field)
     |> handle_got_users()
   end
 


### PR DESCRIPTION
extracted all knowledge of HTTPoison to a single module and in turn make the code more DRY, avoiding passing the same options to parse the response body